### PR TITLE
implement zlib decompression

### DIFF
--- a/src/decompression.c
+++ b/src/decompression.c
@@ -2,6 +2,8 @@
 
 #include<stdlib.h>
 
+#include<zlib.h>
+
 /*
 To implement:
 	Rolling/Normal lzma compression/decompression
@@ -40,7 +42,149 @@ err movie_uncomp(FILE *swf, pdata *state)
 err movie_deflate(FILE *swf, pdata *state)
 {
 	err handler_ret;
-	C_RAISE_ERR(EFN_NIB_HI);
+
+	uchar *uncomp = malloc(state->reported_movie_size);
+	if (!uncomp)
+		return EMM_ALLOC;
+
+	// TODO: sizes cast to unsigned int here
+	z_stream zs = {
+		.next_out = uncomp,
+		.avail_out = state->reported_movie_size,
+	};
+
+	if (inflateInit(&zs) != Z_OK)
+	{
+		free(uncomp);
+		return EMM_ALLOC;
+	}
+
+	int zret = 0;
+	while (zs.avail_out)
+	{
+		uchar buf[16*1024];
+
+		size_t rv = fread(buf, 1, sizeof(buf), swf);
+		if (!rv)
+			break;
+
+		zs.next_in = buf;
+		zs.avail_in = rv;
+
+		while (zs.avail_in && zs.avail_out)
+		{
+			zret = inflate(&zs, Z_NO_FLUSH);
+
+			if (zret != Z_OK && zret != Z_STREAM_END)
+			{
+				if (zret == Z_NEED_DICT)
+					zret = Z_DATA_ERROR;
+
+				goto end;
+			}
+		}
+	}
+
+end:
+
+	inflateEnd(&zs);
+
+	state->movie_size = (zs.next_out - uncomp);
+	state->u_movie = uncomp;
+
+	if (zret < 0)
+	{
+		// decompression error
+		// make this fatal if nothing was decompressed
+		if (!state->movie_size)
+		{
+			C_RAISE_ERR(ESW_IMPROPER);
+			return 0;
+		}
+		else
+		{
+			// just a corrupt file
+			// flash could still play this
+			handler_ret = push_peculiarity(state, PEC_FILESIZE_SMALL, 0);
+			if(ER_ERROR(handler_ret))
+			{
+				return handler_ret;
+			}
+		}
+	}
+	if (ferror(swf))
+	{
+		// read error
+		C_RAISE_ERR(EFL_READ);
+		return 0;
+	}
+
+	// file cut short -> !end
+	// header size too short -> !end && output full && data remaining in file
+	// header size too long -> end && no more data, output has unused space
+	// extra data -> end && data remaining in buffer or file
+
+	// is there file data remaining that we didn't use?
+	// check both the buffer and the actual file
+	// feof isn't necessarily true if it didn't try reading past the last byte
+	int data_remaining;
+	if (zs.avail_in)
+		data_remaining = 1;
+	else if (feof(swf))
+		data_remaining = 0;
+	else
+	{
+		char tmp;
+		data_remaining = !!fread(&tmp, 1, 1, swf);
+	}
+
+	if (zret != Z_STREAM_END)
+	{
+		// didn't decompress the entire stream
+
+		if (!data_remaining)
+		{
+			// unexpected end of file
+			handler_ret = push_peculiarity(state, PEC_FILESIZE_SMALL, 0);
+			if(ER_ERROR(handler_ret))
+			{
+				return handler_ret;
+			}
+		}
+		else if (data_remaining && !zs.avail_out)
+		{
+			// header size too short
+			handler_ret = push_peculiarity(state, PEC_FILESIZE_SMALL, 0);
+			if(ER_ERROR(handler_ret))
+			{
+				return handler_ret;
+			}
+		}
+	}
+	else
+	{
+		// decompressed the entire stream
+
+		if (data_remaining)
+		{
+			// junk data after compressed body
+			handler_ret = push_peculiarity(state, PEC_FILESIZE_SMALL, 0);
+			if(ER_ERROR(handler_ret))
+			{
+				return handler_ret;
+			}
+		}
+		else if (!data_remaining && zs.avail_out)
+		{
+			// header size too long
+			handler_ret = push_peculiarity(state, PEC_FILESIZE_SMALL, 0);
+			if(ER_ERROR(handler_ret))
+			{
+				return handler_ret;
+			}
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
- users of the library now need to link their binary with `-lz` on the command line to link in zlib
- this should(?) handle all possible errors that can happen when decompressing
- i was lazy and reused `PEC_FILESIZE_SMALL` instead of adding new peculiarities (i'd like you to add them)
- `// TODO: sizes cast to unsigned int here` - might cause issues trying to read files above `UINT_MAX` in size, but on the other hand flash player wouldn't even open a file that big
- it would be nice to have unit tests for the library, something that could be ran with a `make test` to check the below cases

commands i used to test the different error cases:

```sh
# get the file from https://archive.4plebs.org/f/search/image/TCDOa7TZYiaF7mSyMUeDyw/

# decompression error
(
	cat ~/flash/ABLOYKEY.swf | head -c -11111
	for n in $(seq 0 255); do
		printf "\\x$(printf '%02x' $n)"
	done
) | ./swfcheck

# unexpected end of file
cat ~/flash/ABLOYKEY.swf | head -c -1 | ./swfcheck

# junk data after compressed body
( cat ~/flash/ABLOYKEY.swf; printf a ) | ./swfcheck

# header size too short
(
	head -c4 ~/flash/ABLOYKEY.swf
	# orig \x51\x73\x00\x00
	printf '\x50\x73\x00\x00'
	tail -c +9 ~/flash/ABLOYKEY.swf
) | ./swfcheck

# header size too long
(
	head -c4 ~/flash/ABLOYKEY.swf
	# orig \x51\x73\x00\x00
	printf '\x52\x73\x00\x00'
	tail -c +9 ~/flash/ABLOYKEY.swf
) | ./swfcheck
```