### PR TITLE
makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,22 @@ all: lib/libswftag.a lib/optional/error.o
 lib/libswftag.a: $(libswftag_objs)
 	ar rcs $@ $^
 
-lib/optional/error.o: src/default/error.o lib/optional
-	mv $< $@
+lib/intermediate/default/error.o: | lib/intermediate/default
 
-lib/intermediate/%.o: src/%.c lib/intermediate
+lib/intermediate/%.o: src/%.c | lib/intermediate
 	$(CC) $(CFLAGS) $(EXTRA_FLAGS) -c $< -o $@
 
+lib/optional/error.o: lib/intermediate/default/error.o | lib/optional
+	cp $< $@
+
 clean:
-	rm -f libswftag.a error.o $(libswftag_objs)
+	-rm -r lib
+
+lib/intermediate/default:
+	mkdir -p $@
 
 lib/intermediate:
 	mkdir -p $@
 
 lib/optional:
 	mkdir -p $@
-
-lib:
-	mkdir $@


### PR DESCRIPTION
- fixed the directory dependencies causing re-running `make` to unnecessarily recompile things (made them an "order-only prerequisite" like described [here](https://stackoverflow.com/a/4481931)). to have it recompile everything, you can still use `make -B` (need this if you make changes to headers for example)

- fixed error.o depending on a built-in rule to run the compiler - found by running with `make -Rr` to disable built-in rules. this is undesirable because it doesn't use the same command we use to compile other object files but a more generic default one (it already lacked the EXTRA_FLAGS from ours)

- removed the unused `lib/` target

- updated the clean target

the choice to have object files in a separate directory complicates the makefile a bit but anyhow, it works now